### PR TITLE
管理画面のページが一瞬見えてしまう問題を修正

### DIFF
--- a/src/app/provider/AuthContext.tsx
+++ b/src/app/provider/AuthContext.tsx
@@ -27,6 +27,10 @@ export function useAuthContext() {
   return context;
 }
 
+export function isLoginRequired(pathname: string) {
+  return pathname.startsWith("/manage") && pathname !== "/manage/login" && pathname !== "/manage/logout";
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const { push } = useRouter();
   const pathname = usePathname();
@@ -54,16 +58,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!isAuthReady) return;
 
-    if (pathname.startsWith("/manage")) {
-      if (!isLogin && pathname !== "/manage/login" && pathname !== "/manage/logout") {
-        push("/manage/login");
-      }
+    if (!isLogin && isLoginRequired(pathname)) {
+      push("/manage/login");
     }
   }, [pathname, push, isLogin, isAuthReady]);
 
-  return (
-    <AuthContext.Provider value={{ user, isLogin, isAuthReady }}>
-      {children}
-    </AuthContext.Provider>
-  );
+  if (!isLogin && isLoginRequired(pathname)) {
+    return (
+      <div>
+        ログインが必要です
+      </div>
+    );
+  } else {
+    return (
+      <AuthContext.Provider value={{ user, isLogin, isAuthReady }}>
+        {children}
+      </AuthContext.Provider>
+    );
+  }
 }


### PR DESCRIPTION
本来，HTTP 401エラーを返すのが最も適切だが，
バックエンド側の対応が必要なため，暫定的な対応を行った．