### PR TITLE
Enhance Crowding Level experience

### DIFF
--- a/src/components/ToiletDetails.tsx
+++ b/src/components/ToiletDetails.tsx
@@ -317,7 +317,7 @@ export const ToiletDetails = ({ toilet: preToilet }: ToiletDetailsProps) => {
           {displayRestTime()}
         </div>
         <span className="block top-0">混雑度投稿</span>
-        <button disabled={! isPostAllowed()} onClick={handleSubmitCrowdLevel} className="flex flex-col items-center text-blue-600/100">
+        <button disabled={! isPostAllowed() || crowdButtonState != STATE_SENDABLE} onClick={handleSubmitCrowdLevel} className="flex flex-col items-center text-blue-600/100">
           {(crowdButtonState == STATE_SENDING ? "投稿中..." : crowdButtonState == STATE_SENT ? "投稿済み" : "混んでいます")}
         </button>
 


### PR DESCRIPTION
混雑度投稿ボタンの使用感を向上

- 混雑度の数値を5秒おきに自動更新するようにした
- window.alertを使わないようにした
- 投稿したらボタンが"投稿済み"になり，押せなくなるようにした．ただしリロードしたらまた投稿できるようになるのは想定内